### PR TITLE
Release 2021 05

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,13 +27,12 @@ var agent = new https.Agent({
     rejectUnauthorized: false
 })
 
-var options = function() {
+var options = function(param_page = 1) {
   return {
     method: 'GET',
     url: `${process.env.HOST}/api/forms/${process.env.FORM_SERIES}/submissions`,
     params: {
-      // Page is now set dynamically before each call.
-      page: 1,
+      page: param_page,
       per_page: PAGINATION_PER_PAGE,
       'filters[FORMHERO.SUBMITTED_AT][type]': 'DATE',
       'filters[[FORMHERO.SUBMITTED_AT][value]': resultWindow(),
@@ -102,10 +101,7 @@ function toCSV (formData){
  * @param {number} page This is the page to return.
  */
 function recursivelyRetrieveDataAndWriteToResponse(res, page = 1) {
-  // FIXME: replace thisRequestOptions with options(page).
-  var thisRequestOptions = options()
-  thisRequestOptions.params.page = page
-  axios.request(thisRequestOptions).then(function (response) {
+  axios.request(options(page)).then(function (response) {
       var result = response.data.data
       res.write(Buffer.from(toCSV(result.map(pickList))))
       var pagination = response.data.meta.pagination

--- a/app.js
+++ b/app.js
@@ -25,7 +25,8 @@ var agent = new https.Agent({
     rejectUnauthorized: false
 })
 
-var options = {
+var options = function() {
+  return {
     method: 'GET',
     url: `${process.env.HOST}/api/forms/${process.env.FORM_SERIES}/submissions`,
     params: {
@@ -45,6 +46,7 @@ var options = {
     },
     httpsAgent: agent
   }
+};
 
 
 
@@ -98,7 +100,7 @@ app.get('/epiCSV', basicAuth({
     challenge: true,
 }),(req, res) => {  
     console.log(` ${new Date()} ${req.method} ${req.path} ${req.ip}`) 
-    axios.request(options).then(function (response) {
+    axios.request(options()).then(function (response) {
         var result = response.data.data
         res.header('Content-Type', 'text/csv')
         res.send(Buffer.from(toCSV(result.map(pickList))))

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ const app = express()
 const port = process.env.PORT
 
 const PASSWORD = process.env.PASSWORD
-const USER = process.env.USER
+const USER = process.env.USERNAME
 const DAYS = 21
 
 const PAGINATION_PER_PAGE = 1000
@@ -172,7 +172,7 @@ app.get('/status', (req, res) => {
   
 
 app.get('/epiCSV', basicAuth({
-    users: { 'admin' : PASSWORD },
+    users: { [USER] : PASSWORD },
     challenge: true,
 }),(req, res) => {  
     console.log(` ${new Date()} ${req.method} ${req.path} ${req.ip}`)
@@ -181,7 +181,7 @@ app.get('/epiCSV', basicAuth({
 })
 
 app.get('/epiCSVByDay', basicAuth({
-    users: { 'admin' : PASSWORD },
+    users: { [USER] : PASSWORD },
     challenge: true,
 }),(req, res) => {
     console.log(` ${new Date()} ${req.method} ${req.path} ${req.ip}`)
@@ -191,6 +191,7 @@ app.get('/epiCSVByDay', basicAuth({
 
 
 app.listen(port, () => {
+    console.log({ [USER] : PASSWORD })
     console.log(`Epi-App listeing at http://localhost:${port}`)
   })
 //console.log(results)

--- a/app.js
+++ b/app.js
@@ -9,6 +9,8 @@ const PASSWORD = process.env.PASSWORD
 const USER = process.env.USER
 const DAYS = 21
 
+const PAGINATION_PER_PAGE = 1000
+
 const https = require('https');
 
 //Basic Auth Setup
@@ -29,8 +31,9 @@ var options = {
     method: 'GET',
     url: `${process.env.HOST}/api/forms/${process.env.FORM_SERIES}/submissions`,
     params: {
-      page: '1',
-      per_page: '5000',
+      // Page is now set dynamically before each call.
+      page: 1,
+      per_page: PAGINATION_PER_PAGE,
       'filters[FORMHERO.SUBMITTED_AT][type]': 'DATE',
       'filters[[FORMHERO.SUBMITTED_AT][value]': resultWindow(),
       'filters[[FORMHERO.SUBMITTED_AT][query]': 'GT',
@@ -88,6 +91,34 @@ function toCSV (formData){
     return headers + p.slice(2,-2)
 }
 
+/**
+ * Retrieve data from the API endpoint, dealing with pagination.
+ *
+ * This function ends the response once pagination is complete.
+ *
+ * @param {object} res This is the Express response object.
+ * @param {number} page This is the page to return.
+ */
+function recursivelyRetrieveDataAndWriteToResponse(res, page = 1) {
+  // FIXME: replace thisRequestOptions with options(page).
+  var thisRequestOptions = options
+  thisRequestOptions.params.page = page
+  axios.request(thisRequestOptions).then(function (response) {
+      var result = response.data.data
+      res.write(Buffer.from(toCSV(result.map(pickList))))
+      var pagination = response.data.meta.pagination
+      if (pagination && pagination.current_page != pagination.total_pages) {
+        // Recursively request the next page of results.
+        recursivelyRetrieveDataAndWriteToResponse(res, pagination.current_page + 1)
+      } else {
+        // Close the connection once we're done.
+        res.end();
+      }
+    }).catch(function (error) {
+      console.error(error);
+    });
+}
+
 app.get('/status', (req, res) => {
     res.send({"status":'OK'})
   })
@@ -97,15 +128,9 @@ app.get('/epiCSV', basicAuth({
     users: { 'admin' : PASSWORD },
     challenge: true,
 }),(req, res) => {  
-    console.log(` ${new Date()} ${req.method} ${req.path} ${req.ip}`) 
-    axios.request(options).then(function (response) {
-        var result = response.data.data
-        res.header('Content-Type', 'text/csv')
-        res.send(Buffer.from(toCSV(result.map(pickList))))
-        //res.send(toCSV(result.map(pickList)))
-      }).catch(function (error) {
-        console.error(error);
-      });
+    console.log(` ${new Date()} ${req.method} ${req.path} ${req.ip}`)
+    res.header('Content-Type', 'text/csv')
+    recursivelyRetrieveDataAndWriteToResponse(res)
 })
 
 


### PR DESCRIPTION
# Includes

- Handles pagination
- Fix "static" date filter
- New `/epiCSVByDay` endpoint
- Remove hard-coded credentials

**Handles pagination**

The main endpoint, `/epiCSV` now supports result sets that exceed the per-request row limit. Default results per request set to 1000, in line with Proof defaults. Fixes ryanjagar#4

**Fix "static" date filter**

The original implementation accidentally set the time window at application startup time. The value is now calculated for each request. Fixes ryanjagar#7

**New `/epiCSVByDay` endpoint**

This endpoint does not support pagination. It was created as an alternative to pagination, while issues with sort order were being investigated.

**Remove hard-coded credentials**

The HTTP auth username was previously fixed. It is now set based on the value of `USERNAME` in the `.env` file. Fixes ryanjagar#2

# Deployment instructions

1. Roll out the code
2. Restart the app